### PR TITLE
add documentation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 authors = ["杜世橋 Du Shiqiao <lucidfrontier.45@gmail.com>"]
 readme = "README.md"
 license = "MIT"
+documentation = "https://docs.rs/heapq"
 repository = "https://github.com/lucidfrontier45/heapq"
 homepage = "https://crates.io/crates/heapq"
 categories = ["data-structures", "algorithms"]

--- a/examples/usage.rs
+++ b/examples/usage.rs
@@ -1,18 +1,3 @@
-# Heapq
-Priority Queue with scoring function
-
-# Usage
-
-```toml
-[dependencies]
-heapq = "0.1.0"
-```
-
-In the code you first need to create an instance with `heaqp::PriorityQueue::new`. It takes a closure that converts your item type `&T` into score type `S: Ord`. Then you can use `push/pop/peek` methods in the same way as `std::collections::BinaryHeap`.
-
-# Example
-
-```rust
 use std::cmp::Reverse;
 
 use heapq::PriorityQueue;
@@ -65,4 +50,3 @@ fn main() {
     assert_eq!(queue.pop(), Some("b".to_string()));
     assert!(queue.peek().is_none());
 }
-```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,8 @@
+#![forbid(missing_docs)]
+#![allow(clippy::non_ascii_literal)]
+#![allow(clippy::module_name_repetitions)]
+#![doc = include_str!("../README.md")]
+
 mod queue;
 mod scored_item;
 

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -2,32 +2,39 @@ use std::collections::BinaryHeap;
 
 use crate::scored_item::ScoredItem;
 
+/// A priority queue with a score function.
 pub struct PriorityQueue<T, S: Ord, F: Fn(&T) -> S> {
     heap: BinaryHeap<ScoredItem<T, S>>,
     score_fn: F,
 }
 
 impl<T, S: Ord, F: Fn(&T) -> S> PriorityQueue<T, S, F> {
+    /// Creates a new priority queue with the given score function.
     pub fn new(score_fn: F) -> Self {
         let heap = BinaryHeap::new();
         Self { heap, score_fn }
     }
 
+    /// Returns the reference to the first elements in the queue.
     pub fn peek(&self) -> Option<&T> {
         self.heap.peek().map(|item| &item.item)
     }
 
+    /// Returns the first elements in the queue.
     pub fn pop(&mut self) -> Option<T> {
         self.heap.pop().map(|item| item.item)
     }
 
-    pub fn push_with_score(&mut self, item: T, score: S) {
-        self.heap.push(ScoredItem { item, score });
-    }
-
+    /// Pushes an item into the queue.
+    /// The score of the item is calculated by the score function.
     pub fn push(&mut self, item: T) {
         let score = (self.score_fn)(&item);
         self.push_with_score(item, score);
+    }
+    /// Pushes an item into the queue with the given score
+    /// without using the score function.
+    pub fn push_with_score(&mut self, item: T, score: S) {
+        self.heap.push(ScoredItem { item, score });
     }
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->


### Summary by CodeRabbit

- New Feature: Introduced a new `heapq` crate for managing priority queues in Rust. This includes methods for adding items, viewing the highest priority item, and removing items based on their priority.
- Documentation: Added comprehensive documentation comments for the new `heapq` crate, including a detailed usage guide and examples.
- Improvement: Enhanced the `push` method to automatically calculate the score using the provided score function, simplifying the process of adding items to the queue.
- New Feature: Added a `push_with_score` method, allowing users to manually specify an item's score when adding it to the queue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->